### PR TITLE
Revert back to lrzsz 0.12.20

### DIFF
--- a/org.gnome.moserial.yaml
+++ b/org.gnome.moserial.yaml
@@ -22,8 +22,8 @@ modules:
       - --program-transform-name=s/l//
     sources:
       - type: archive
-        url: https://ohse.de/uwe/testing/lrzsz-0.12.21rc.tar.gz
-        sha256: 4d845f239ddcd86735b5dbf01f3869b072ffb6f6c8aa24c346dc4a3c95453c55
+        url: https://www.ohse.de/uwe/releases/lrzsz-0.12.20.tar.gz
+        sha256: c28b36b14bddb014d9e9c97c52459852f97bd405f89113f30bee45ed92728ff1
     cleanup:
       - /share/man
       - /man


### PR DESCRIPTION
I think 0.12.21rc was causing problems.
The serial monitor didn't appear to work.
I'm reverting back to the old version for now.